### PR TITLE
fix bug with sending reset password

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -965,7 +965,7 @@ sub _post_login_route {
     {
         my $username = $app->request->param('username_reset');
         croak "Attempt to pass reference to reset blocked" if ref $username;
-        $app->password_reset_send( username => $username );
+        $plugin->password_reset_send( username => $username );
         $app->forward(
             $plugin->login_page,
             { reset_sent => 1 },


### PR DESCRIPTION
This fixes an error:
Can't locate object method "password_reset_send" via package "Dancer2::Core::App" at /usr/local/share/perl/5.22.1/Dancer2/Plugin/Auth/Extensible.pm line 990.

password_reset_send is a method of plugin, not the app
